### PR TITLE
add configuration spec for lager graylog exporter

### DIFF
--- a/config/exlager.conf
+++ b/config/exlager.conf
@@ -6,6 +6,12 @@ log.journal.level = false
 # Allowed values: info, error, false
 log.console.level = info
 
+# Be careful, if level is set to false or omitted, the other gelf options must be omitted too.
+# Otherwise lager will crash when starting.
+log.gelf.level = debug
+log.gelf.host = graylog.erlang-solutions.com
+log.gelf.port = 8000
+
 # Specify the path to the error log for the file backend
 log.file.error = false
 

--- a/config/exlager.schema.exs
+++ b/config/exlager.schema.exs
@@ -16,6 +16,30 @@
       datatype: [enum: [:info, :error, :false]],
       default: :info
     ],
+    "log.gelf.level": [
+      doc: """
+      Choose the logging level for the graylog backend.
+      """,
+      to: "lager.handlers",
+      datatype: [enum: [:emerg, :alert, :crit, :error, :warning, :notive, :info, :debug, :false]],
+      default: :false
+    ],
+    "log.gelf.host": [
+      doc: """
+      Hostname of the graylog server to forward log messages to.
+      """,
+      to: "lager.handlers",
+      datatype: :string,
+      default: ""
+    ],
+    "log.gelf.port": [
+      doc: """
+      Port of the graylog server to forward log messages to.
+      """,
+      to: "lager.handlers",
+      datatype: :integer,
+      default: 0
+    ],
     "log.file.error": [
       doc: """
       Specify the path to the error log for the file backend
@@ -59,6 +83,70 @@
       _, level, _ ->
         IO.puts("Unsupported console logging level: #{level}")
         exit(1)
+    end,
+    "log.gelf.level": fn
+      _mapping, false, acc ->
+          (acc || [])
+      _mapping, level, acc when level in [:emerg, :alert, :crit, :error, :warning, :notive, :info, :debug] ->
+        old_data = case acc[:lager_udp_backend] do
+                     [:info | rest] -> rest
+                     _ -> []
+                   end
+        append_port = case old_data[:port] do
+                        nil -> []
+                        val -> [port: val]
+                      end
+        append_host = case old_data[:host] do
+                        nil -> []
+                        val -> [host: val]
+                      end
+        Dict.put(acc || [], :lager_udp_backend, [:info,
+                                                 {:level, level},
+                                                 {:formatter, :lager_gelf_formatter},
+                                                 {:formatter_config, [{:metadata, [{:service, "SERVICE NAME"}]}]}] ++ append_host ++ append_port)
+      _, level, _ ->
+        IO.puts("Unsupported journal logging level: #{level}")
+        exit(1)
+    end,
+    "log.gelf.host": fn
+      _mapping, "", acc -> acc
+      _mapping, host, acc ->
+        old_data = case acc[:lager_udp_backend] do
+                     [:info | rest] -> rest
+                     _ -> []
+                   end
+        append_level = case old_data[:level] do
+                         nil -> []
+                         val -> [level: val]
+                       end
+        append_port = case old_data[:port] do
+                        nil -> []
+                        val -> [port: val]
+                      end
+        Dict.put(acc || [], :lager_udp_backend, [:info,
+                                                 {:host, host},
+                                                 {:formatter, :lager_gelf_formatter},
+                                                 {:formatter_config, [{:metadata, [{:service, "SERVICE NAME"}]}]}] ++ append_level ++ append_port)
+    end,
+    "log.gelf.port": fn
+      _mapping, 0, acc -> acc
+      _mapping, port, acc ->
+        old_data = case acc[:lager_udp_backend] do
+                     [:info | rest] -> rest
+                     _ -> []
+                   end
+        append_level = case old_data[:level] do
+                         nil -> []
+                         val -> [level: val]
+                       end
+        append_host = case old_data[:host] do
+                        nil -> []
+                        val -> [host: val]
+                      end
+        Dict.put(acc || [], :lager_udp_backend, [:info,
+                                                 {:port, port},
+                                                 {:formatter, :lager_gelf_formatter},
+                                                 {:formatter_config, [{:metadata, [{:service, "SERVICE NAME"}]}]}]  ++ append_level ++ append_host)
     end,
     "log.file.error": fn
       _, 'false', acc ->


### PR DESCRIPTION
Spec is quite ugly because the graylog exporter config is no complex type but it is also more complex then a regular value.
