### PR TITLE
Accept metadata as list

### DIFF
--- a/lib/lager.ex
+++ b/lib/lager.ex
@@ -63,6 +63,9 @@ defmodule Lager do
     end
   end
 
+  defp dispatch(level, module, name, line, format, args, meta) when is_list(meta) do
+     dispatch(level, module, name, line, format, args, :maps.from_list(meta)) 
+  end
   defp dispatch(level, module, name, line, format, args, meta) do
     level_pot = level2pot(level)
     quote do


### PR DESCRIPTION
For backward compatibility log calls now accept the metadata in list format.