### PR TITLE
Add JSON console formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 _build/
 deps/
 rel/
-mix.lock

--- a/config/exlager.conf
+++ b/config/exlager.conf
@@ -9,6 +9,10 @@ log.journal.global_meta = ""
 # Allowed values: info, error, false
 log.console.level = info
 
+# Choose the format for console logging.
+# Allowed values: default, json
+log.console.format = default
+
 # Be careful, if level is set to false or omitted, the other gelf options must be omitted too.
 # Otherwise lager will crash when starting.
 log.gelf.level = debug

--- a/lib/lager/json_formatter.ex
+++ b/lib/lager/json_formatter.ex
@@ -1,0 +1,61 @@
+defmodule Lager.JsonFormatter do
+  
+  alias :lager_msg, as: LagerMsg
+
+  @spec format(LagerMsg.lager_msg(), list()) :: any()
+  def format(message, _config) do
+    metadata = LagerMsg.metadata(message)
+    keys = Keyword.keys(metadata)
+    config = [:message, :timestamp, :severity | keys]
+    map = List.foldl(config, %{}, fn(data, acc) ->
+      value = get_data(data, message) |> to_str()
+      key = case data do
+        {_key, default} -> default
+        key -> key
+      end
+      Map.put(acc, key, value)
+    end) 
+    "#{Poison.encode!(map)}" <> "\n"
+  end
+
+  @spec format(LagerMsg.lager_msg(), list(), list()) :: any()
+  def format(message, config, _color), do: format(message, config)
+
+  defp to_str(int) when is_integer(int), do: int
+  defp to_str(map) when is_map(map), 
+    do: for {k, v} <- map, into: %{}, do: {k, to_str(v)}
+  defp to_str([{key, _}|_] = keyword) when is_atom(key), 
+    do: Map.new(keyword) |> to_str()
+  defp to_str(value), do: to_string(value)
+
+  defp get_data(value, _) when is_list(value) or is_binary(value), do: value
+
+  defp get_data(:message, message), do: LagerMsg.message(message) 
+
+  defp get_data(:timestamp, message), do:
+    LagerMsg.timestamp(message) 
+    |> format_timestap()
+
+  defp get_data(:severity, message), do: LagerMsg.severity(message) 
+
+  defp get_data(metadata, message) when is_atom(metadata), do: 
+    get_data({metadata, "undefined"}, message)
+
+  defp get_data({metadata, absent}, message) do
+    md = LagerMsg.metadata(message)
+    case Keyword.get(md, metadata) do
+      nil -> absent
+      value when is_pid(value) -> :erlang.pid_to_list(value)
+      value -> value
+    end
+  end
+
+  defp format_timestap(timestamp), do:
+    timestamp
+    |> :calendar.now_to_local_time()
+    |> format_datetime()
+
+  defp format_datetime({{y, m, d}, {h, mm, s}}), do:
+    "#{y}-#{m}-#{d} #{h}:#{mm}:#{s}"
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Exlager.Mixfile do
 
   defp deps do
     [
-      {:lager, "~> 3.2.1"}
+      {:lager, "~> 3.6.3"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule Exlager.Mixfile do
 
   defp deps do
     [
-      {:lager, "~> 3.6.3"}
+      {:lager,   "~> 3.6.3"},
+      {:poison,  "~> 3.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "goldrush": {:hex, :goldrush, "0.1.9", "f06e5d5f1277da5c413e84d5a2924174182fb108dabb39d5ec548b27424cd106", [:rebar3], [], "hexpm"},
+  "lager": {:hex, :lager, "3.6.3", "fe78951d174616273f87f0dbc3374d1430b1952e5efc4e1c995592d30a207294", [:rebar3], [{:goldrush, "0.1.9", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
   "goldrush": {:hex, :goldrush, "0.1.9", "f06e5d5f1277da5c413e84d5a2924174182fb108dabb39d5ec548b27424cd106", [:rebar3], [], "hexpm"},
   "lager": {:hex, :lager, "3.6.3", "fe78951d174616273f87f0dbc3374d1430b1952e5efc4e1c995592d30a207294", [:rebar3], [{:goldrush, "0.1.9", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/test/exlager_json_test.exs
+++ b/test/exlager_json_test.exs
@@ -1,0 +1,42 @@
+defmodule ExLager.JsonTest do
+  use ExUnit.Case
+
+  require Lager
+
+  # NOTE
+  # we are not able to capture lager output now
+  # then this tests is only for checking by eyes
+
+  test "Info with simple meta" do
+    Lager.info("Message", [], [a: 1])
+  end
+
+  test "info with meta contains nested map" do
+    Lager.info("Another message with nested data", [], [map: %{:c => 1}])
+  end
+
+  test "info with meta contains nested keyword" do
+    Lager.info("Another message with nested data", [], [keyword: [c: 1]])
+  end
+
+  test "info with deep nested data" do
+    meta = [a: 1,
+            map: %{
+              :keyword => [int: 2],
+              :map => %{int: 2}
+            }
+    ]
+    Lager.info("Another message with deep nested data", [], meta)
+  end
+
+  setup do
+    Application.stop(:lager)
+    Application.load(:lager)
+    config = [level: :info,
+              formatter: Lager.JsonFormatter,
+              formatter_config: []
+    ]
+    Application.put_env(:lager, :handlers, [lager_console_backend: config])
+    Application.start(:lager)
+  end
+end


### PR DESCRIPTION
this commit adds `Lager.JsonFormatter` which can be used as formatter for
the console backend. Right now, it used pre-defined options and it is
not possible to change them.

Note that the formatter tries to cast nested maps and keywords.

Poison is used as JSON parser. It is easy to move to Jason when it's
needed.

In application which uses exlager console formatter can be changes via
the following option:

    log.console.format = default | json