### PR TITLE
allow to use binaries/strings in metadata keys

### DIFF
--- a/lib/lager/json_formatter.ex
+++ b/lib/lager/json_formatter.ex
@@ -33,8 +33,6 @@ defmodule Lager.JsonFormatter do
   end
   defp to_str(value), do: to_string(value)
 
-  defp get_data(value, _) when is_list(value) or is_binary(value), do: value
-
   defp get_data(:message, message), do: LagerMsg.message(message) 
 
   defp get_data(:timestamp, message), do:
@@ -43,15 +41,15 @@ defmodule Lager.JsonFormatter do
 
   defp get_data(:severity, message), do: LagerMsg.severity(message) 
 
-  defp get_data(metadata, message) when is_atom(metadata), do: 
+  defp get_data(metadata, message) when is_atom(metadata) or is_list(metadata) or is_binary(metadata), do: 
     get_data({metadata, "undefined"}, message)
 
   defp get_data({metadata, absent}, message) do
     md = LagerMsg.metadata(message)
-    case Keyword.get(md, metadata) do
+    case List.keyfind(md, metadata, 0) do
       nil -> absent
-      value when is_pid(value) -> :erlang.pid_to_list(value)
-      value -> value
+      {_, value} when is_pid(value) -> :erlang.pid_to_list(value)
+      {_, value} -> value
     end
   end
 

--- a/test/exlager_json_test.exs
+++ b/test/exlager_json_test.exs
@@ -43,6 +43,14 @@ defmodule ExLager.JsonTest do
     Lager.info("Another message with deep nested data", [], meta)
   end
 
+  test "allow binaries in meta keys" do
+    meta = [
+      {"a", 1},
+      {"b", 2}
+    ]
+    Lager.info("Another message with deep nested data", [], meta)
+  end
+  
   setup do
     Application.stop(:lager)
     Application.load(:lager)


### PR DESCRIPTION
The problem is that when a binary or string is used in metadata keys
Json formatter treats such keys as values and mapping was wrong.
    
For example:
    
        meta = [
          {"a", 1},
          {"b", 2}
        ]
    
Expected mapping for such metadata is:
    
        %{"a": 1, "b": 2, "timestamp": "2019-02-14 09:24:51.701894Z"}
 
 But JsonFormatter treated such (non-atom) keys as values, so the
 result was:
    
        %{"a": "a", "b": "b", "timestamp": "timestamp"}

This commit should fix this issue.