### PR TITLE
add utf8 specifier for string values JsonFormatter

### DIFF
--- a/lib/lager/json_formatter.ex
+++ b/lib/lager/json_formatter.ex
@@ -13,6 +13,11 @@ defmodule Lager.JsonFormatter do
         {_key, default} -> default
         key -> key
       end
+      value = if is_binary(value) do
+                for <<c <- value>>, into: <<>>, do: <<c::utf8>>
+              else
+                value
+              end
       Map.put(acc, key, value)
     end) 
     "#{Poison.encode!(map)}" <> "\n"


### PR DESCRIPTION
Otherwise it will be crashed in a case there will be symbol > 127
in ascii as Poison handles ascii and utf8 symbols in different
ways, see Poison.EncodeError.escape/3 for more info
